### PR TITLE
chore: add commitizen to enforce conventional commits

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+venv/bin/cz check --allow-abort --commit-msg-file $1

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ barcode.
 ## Documentations
 
 Find the full documentation [here](https://the-broke-sommeliers.github.io/wine-cellar/)
+
+## Development
+
+This projects uses [Conventinal Commits](https://www.conventionalcommits.org/en/v1.0.0/) for all commit messages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wine_cellar"
+version = "0.0.12"
 authors = [
     {name = "Julian Dehm", email = "julian@dehm.dev"},
     {name = "Phillippa Morland"},
@@ -35,3 +36,12 @@ python_files = ["test_*.py", "*_test.py"]
 [tool.coverage.run]
 omit = ["wine_cellar/conf/*","**/tests/*", "**/migrations/*"]
 
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "$version"
+version_scheme = "semver2"
+version_provider = "pep621"
+update_changelog_on_bump = true
+major_version_zero = true
+changelog_incremental = true

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,3 +12,4 @@ pytest-cov==7.0.0
 pytest-django==4.11.1
 pytest-factoryboy==2.8.1
 pytest==8.4.2
+commitizen==4.9.1


### PR DESCRIPTION
This will make releases much easier and enforce a consistent commit style