### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/the-broke-sommeliers/wine-cellar/security/code-scanning/1](https://github.com/the-broke-sommeliers/wine-cellar/security/code-scanning/1)

In general, the problem is fixed by defining a `permissions` block that limits the `GITHUB_TOKEN` to the minimal scopes required. This can be done at the workflow root (applies to all jobs) or per job. Since the given file has a single `build` job and there’s no indication other jobs require different scopes, adding a root-level `permissions` block is the simplest fix.

The single best fix here is to add:

```yaml
permissions:
  contents: read
```

at the top level of the workflow (between `on:` and `jobs:`), so that all jobs, including `build`, inherit read-only access to repository contents. None of the steps shown require write access to repository contents, issues, or pull requests; `actions/checkout`, `actions/cache`, `actions/setup-*`, and the Coveralls action work with read-only repo access in typical CI setups. No other changes to steps or actions are needed.

Concretely, in `.github/workflows/ci.yml`, insert a new `permissions` block after the `on:` section (after line 7, before line 9). No imports or additional definitions are required because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
