### PR TITLE
fix(docker): fix DJANGO_ENABLE_SIGNUPS variable not working as intended

### DIFF
--- a/wine_cellar/conf/docker_settings.py
+++ b/wine_cellar/conf/docker_settings.py
@@ -27,7 +27,7 @@ STATIC_ROOT = "staticfiles"
 
 SITE_URL = os.environ.get("DJANGO_SITE_URL")
 
-ENABLE_SIGNUPS = os.environ.get("DJANGO_ENABLE_SIGNUPS", False)
+ENABLE_SIGNUPS = os.environ.get("DJANGO_ENABLE_SIGNUPS", "False") == "True"
 
 EMAIL_HOST = os.environ.get("DJANGO_EMAIL_HOST")
 EMAIL_PORT = os.environ.get("DJANGO_EMAIL_PORT")


### PR DESCRIPTION
When `DJANGO_ENABLE_SIGNUPS` is set to "False" it still allowed signups. If you didn't want to allow signups please check if any users registered in the django-admin under `/admin`.